### PR TITLE
N8vm/python bindings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.13)
 project(nlxml)
 
+option (BUILD_PYTHON_BINDINGS "Build python bindings using SWIG" OFF)
+
 # Bump up warning levels appropriately for each compiler
 if (UNIX OR APPLE OR MINGW)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -pedantic")
@@ -13,13 +15,15 @@ elseif (MSVC)
 	endif()
 endif()
 
-# Python Bindings
-find_package(SWIG 3.0.8 REQUIRED)
-include(${SWIG_USE_FILE})
-cmake_policy(SET CMP0078 NEW)
-
-find_package(Python3 3.6 COMPONENTS Interpreter Development REQUIRED)
-include_directories(SYSTEM ${Python3_INCLUDE_DIRS})
+if (BUILD_PYTHON_BINDINGS)
+	# Python Bindings
+	find_package(SWIG 3.0.8 REQUIRED)
+	include(${SWIG_USE_FILE})
+	cmake_policy(SET CMP0078 NEW)
+	
+	find_package(Python3 3.6 COMPONENTS Interpreter Development REQUIRED)
+	include_directories(SYSTEM ${Python3_INCLUDE_DIRS})
+endif()
 
 add_library(nlxml nlxml.cpp tinyxml2.cpp)
 set_target_properties(nlxml PROPERTIES
@@ -31,42 +35,45 @@ target_include_directories(nlxml PUBLIC
 	$<INSTALL_INTERFACE:include>
 )
 
-set (
-    LIBRARIES
-    ${Python3_LIBRARIES}
-    nlxml
-)
+if (BUILD_PYTHON_BINDINGS)
+	set (
+		LIBRARIES
+		${Python3_LIBRARIES}
+		nlxml
+	)
 
-set_property(SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/NLXMLBindings.i PROPERTY CPLUSPLUS ON)
-set_property(SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/NLXMLBindings.i PROPERTY USE_TARGET_INCLUDE_DIRECTORIES TRUE)
-swig_add_library(NLXMLBindings TYPE SHARED LANGUAGE python OUTFILE_DIR ${CMAKE_CURRENT_SOURCE_DIR} SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/NLXMLBindings.i)
-set_target_properties(NLXMLBindings PROPERTIES INSTALL_RPATH "${RPATHS}")
-set_target_properties(NLXMLBindings PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE)
-target_link_libraries(NLXMLBindings PUBLIC ${LIBRARIES})
+	set_property(SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/NLXMLBindings.i PROPERTY CPLUSPLUS ON)
+	set_property(SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/NLXMLBindings.i PROPERTY USE_TARGET_INCLUDE_DIRECTORIES TRUE)
+	swig_add_library(NLXMLBindings TYPE SHARED LANGUAGE python OUTFILE_DIR ${CMAKE_CURRENT_SOURCE_DIR} SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/NLXMLBindings.i)
+	set_target_properties(NLXMLBindings PROPERTIES INSTALL_RPATH "${RPATHS}")
+	set_target_properties(NLXMLBindings PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE)
+	target_link_libraries(NLXMLBindings PUBLIC ${LIBRARIES})
 
-install(TARGETS nlxml EXPORT nlxmlConfig
-	LIBRARY DESTINATION lib
-	ARCHIVE DESTINATION lib
-	RUNTIME DESTINATION bin
-	INCLUDES DESTINATION include
-)
-install(FILES nlxml.h
-	DESTINATION include
-)
-install(EXPORT nlxmlConfig
-	DESTINATION lib/cmake/nlxml
-)
+	install(TARGETS nlxml EXPORT nlxmlConfig
+		LIBRARY DESTINATION lib
+		ARCHIVE DESTINATION lib
+		RUNTIME DESTINATION bin
+		INCLUDES DESTINATION include
+	)
+	install(FILES nlxml.h
+		DESTINATION include
+	)
+	install(EXPORT nlxmlConfig
+		DESTINATION lib/cmake/nlxml
+	)
 
-# Install
-install(FILES ${CMAKE_BINARY_DIR}/NLXMLBindings.py DESTINATION ${CMAKE_INSTALL_PREFIX})
+	# Install
+	install(FILES ${CMAKE_BINARY_DIR}/NLXMLBindings.py DESTINATION ${CMAKE_INSTALL_PREFIX})
 
-if (WIN32) 
-install(FILES ${CMAKE_BINARY_DIR}/_NLXMLBindings.pyd DESTINATION ${CMAKE_INSTALL_PREFIX})
-install(FILES ${CMAKE_BINARY_DIR}/_NLXMLBindings.pdb DESTINATION ${CMAKE_INSTALL_PREFIX} OPTIONAL)
-elseif(APPLE)
-install(FILES ${CMAKE_BINARY_DIR}/_NLXMLBindings.so DESTINATION ${CMAKE_INSTALL_PREFIX})
-else()
-install(FILES ${CMAKE_BINARY_DIR}/_NLXMLBindings.so DESTINATION ${CMAKE_INSTALL_PREFIX})
+	if (WIN32) 
+	install(FILES ${CMAKE_BINARY_DIR}/_NLXMLBindings.pyd DESTINATION ${CMAKE_INSTALL_PREFIX})
+	install(FILES ${CMAKE_BINARY_DIR}/_NLXMLBindings.pdb DESTINATION ${CMAKE_INSTALL_PREFIX} OPTIONAL)
+	elseif(APPLE)
+	install(FILES ${CMAKE_BINARY_DIR}/_NLXMLBindings.so DESTINATION ${CMAKE_INSTALL_PREFIX})
+	else()
+	install(FILES ${CMAKE_BINARY_DIR}/_NLXMLBindings.so DESTINATION ${CMAKE_INSTALL_PREFIX})
+	endif()
+
 endif()
 
 add_subdirectory(utils)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.13)
 project(nlxml)
 
 # Bump up warning levels appropriately for each compiler
@@ -13,6 +13,14 @@ elseif (MSVC)
 	endif()
 endif()
 
+# Python Bindings
+find_package(SWIG 3.0.8 REQUIRED)
+include(${SWIG_USE_FILE})
+cmake_policy(SET CMP0078 NEW)
+
+find_package(Python3 3.6 COMPONENTS Interpreter Development REQUIRED)
+include_directories(SYSTEM ${Python3_INCLUDE_DIRS})
+
 add_library(nlxml nlxml.cpp tinyxml2.cpp)
 set_target_properties(nlxml PROPERTIES
 	POSITION_INDEPENDENT_CODE ON
@@ -22,6 +30,19 @@ target_include_directories(nlxml PUBLIC
 	$<BUILD_INTERFACE:${nlxml_SOURCE_DIR}>
 	$<INSTALL_INTERFACE:include>
 )
+
+set (
+    LIBRARIES
+    ${Python3_LIBRARIES}
+    nlxml
+)
+
+set_property(SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/NLXMLBindings.i PROPERTY CPLUSPLUS ON)
+set_property(SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/NLXMLBindings.i PROPERTY USE_TARGET_INCLUDE_DIRECTORIES TRUE)
+swig_add_library(NLXMLBindings TYPE SHARED LANGUAGE python OUTFILE_DIR ${CMAKE_CURRENT_SOURCE_DIR} SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/NLXMLBindings.i)
+set_target_properties(NLXMLBindings PROPERTIES INSTALL_RPATH "${RPATHS}")
+set_target_properties(NLXMLBindings PROPERTIES INSTALL_RPATH_USE_LINK_PATH TRUE)
+target_link_libraries(NLXMLBindings PUBLIC ${LIBRARIES})
 
 install(TARGETS nlxml EXPORT nlxmlConfig
 	LIBRARY DESTINATION lib
@@ -35,4 +56,16 @@ install(FILES nlxml.h
 install(EXPORT nlxmlConfig
 	DESTINATION lib/cmake/nlxml
 )
+
+# Install
+install(FILES ${CMAKE_BINARY_DIR}/NLXMLBindings.py DESTINATION ${CMAKE_INSTALL_PREFIX})
+
+if (WIN32) 
+install(FILES ${CMAKE_BINARY_DIR}/_NLXMLBindings.pyd DESTINATION ${CMAKE_INSTALL_PREFIX})
+install(FILES ${CMAKE_BINARY_DIR}/_NLXMLBindings.pdb DESTINATION ${CMAKE_INSTALL_PREFIX} OPTIONAL)
+elseif(APPLE)
+install(FILES ${CMAKE_BINARY_DIR}/_NLXMLBindings.so DESTINATION ${CMAKE_INSTALL_PREFIX})
+else()
+install(FILES ${CMAKE_BINARY_DIR}/_NLXMLBindings.so DESTINATION ${CMAKE_INSTALL_PREFIX})
+endif()
 

--- a/NLXMLBindings.i
+++ b/NLXMLBindings.i
@@ -1,12 +1,20 @@
 %module NLXMLBindings
 
-%include <exception.i>
-
 %feature("autodoc","3");
 
 %include "std_string.i"
 %include "std_vector.i"
 %include "stdint.i"
+
+%include "exception.i"
+
+%exception {
+  try {
+    $action
+  } catch (const std::exception& e) {
+    SWIG_exception(SWIG_RuntimeError, e.what());
+  }
+}
 
 %{
 #include "./nlxml.h"

--- a/NLXMLBindings.i
+++ b/NLXMLBindings.i
@@ -1,0 +1,29 @@
+%module NLXMLBindings
+
+%include <exception.i>
+
+%feature("autodoc","3");
+
+%include "std_string.i"
+%include "std_vector.i"
+%include "stdint.i"
+
+%{
+#include "./nlxml.h"
+using namespace nlxml;
+%}
+
+namespace std {
+   %template(UIntVector) vector<uint32_t>;
+   %template(FloatVector) vector<float>;
+
+   %template(PointVector) vector<nlxml::Point>;
+   %template(ColorVector) vector<nlxml::Color>;
+   %template(TreeVector) vector<nlxml::Tree>;
+   %template(BranchVector) vector<nlxml::Branch>;
+   %template(ContourVector) vector<nlxml::Contour>;
+   %template(MarkerVector) vector<nlxml::Marker>;
+   %template(ImageVector) vector<nlxml::Image>;
+};
+
+%include "./nlxml.h"

--- a/nlxml.cpp
+++ b/nlxml.cpp
@@ -2,6 +2,7 @@
 #include <iomanip>
 #include <algorithm>
 #include <iostream>
+#include <stdexcept>
 #include "tinyxml2.h"
 #include "nlxml.h"
 
@@ -117,7 +118,10 @@ Image read_image(const tinyxml2::XMLElement *e) {
 NeuronData import_file(const std::string &fname) {
 	using namespace tinyxml2;
 	XMLDocument doc;
-	doc.LoadFile(fname.c_str());
+	auto result = doc.LoadFile(fname.c_str());
+	if (result != XML_SUCCESS) {
+		throw std::runtime_error("Error: XML file " + fname + " does not exist");
+	}
 	XMLElement *mbf_root = doc.FirstChildElement();
 	NeuronData data;
 	for (XMLElement *e = mbf_root->FirstChildElement(); e != nullptr; e = e->NextSiblingElement()) {

--- a/nlxml.cpp
+++ b/nlxml.cpp
@@ -120,7 +120,7 @@ NeuronData import_file(const std::string &fname) {
 	XMLDocument doc;
 	auto result = doc.LoadFile(fname.c_str());
 	if (result != XML_SUCCESS) {
-		throw std::runtime_error("Error: XML file " + fname + " does not exist");
+		throw std::runtime_error("Error: XML file " + fname + " does not exist, or is unreadable");
 	}
 	XMLElement *mbf_root = doc.FirstChildElement();
 	NeuronData data;


### PR DESCRIPTION
These changes add SWIG bindings to the nlxml.h file, which is helpful for python data wrangling and experimenting.

All major types have vector typemaps, which let you use the same C++ vector API in python.

example usage:

```
import NLXMLBindings as nlxml
data = nlxml.import_file("trace.xml")
tree = data.trees[0]
num_branches = tree.branches.size()
branch = tree.branches[3]
branch_points = branch.points
point_coord = [branch_points[0].x, branch_points[0].y, branch_points[0].z]
```